### PR TITLE
Correct if statement for parameter changes

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -278,7 +278,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
     // if we are updating the k and v_to_h params, then do so if the time is
     // right to do so
     if ((updateParams) && (t % 12 == 0) &&
-        (paramIndex <= (k_vals.size() - 1)) && (t >= outputEndgameDate)) {
+        (paramIndex <= (k_vals.size() - 1)) ) {
       popln.updateKVal(k_vals[paramIndex]);
       vectors.updateVtoH(v_to_h_vals[paramIndex]);
     }

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -278,7 +278,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
     // if we are updating the k and v_to_h params, then do so if the time is
     // right to do so
     if ((updateParams) && (t % 12 == 0) &&
-        (paramIndex <= (k_vals.size() - 1)) ) {
+        (paramIndex <= (k_vals.size() - 1))) {
       popln.updateKVal(k_vals[paramIndex]);
       vectors.updateVtoH(v_to_h_vals[paramIndex]);
     }


### PR DESCRIPTION
There was an erroneous check for `t >= outputEndgameDate` when changing `k` and `v_to_h` parameters within simulations. When fitting `outputEndgameDate` was `0`, so this was always satisfied. When we want to produce outputs for IHME, `outputEndgameDate` is likely non-zero, so there will be a discrepancy here. Remove this to match future results to the fitting.