### PR TITLE
Only perform one importation reduction per year

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -336,7 +336,8 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
     // file for the scenario the time for this will be long after the end of the
     // simulation, so we will never switch to the other method.
     if (!shouldReduceImportationViaPrevalance(
-            reduceImpViaXml, t, popln.switchImportationReducingMethodTime)) {
+            reduceImpViaXml, t, popln.switchImportationReducingMethodTime)&&
+        (t % 12 == 0)) {
       sc.updateImportationRate(popln, t);
     }
     sc.updateBedNetCoverage(popln, t);

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -336,7 +336,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
     // file for the scenario the time for this will be long after the end of the
     // simulation, so we will never switch to the other method.
     if (!shouldReduceImportationViaPrevalance(
-            reduceImpViaXml, t, popln.switchImportationReducingMethodTime)&&
+            reduceImpViaXml, t, popln.switchImportationReducingMethodTime) &&
         (t % 12 == 0)) {
       sc.updateImportationRate(popln, t);
     }

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -33,8 +33,8 @@ TEST_CASE("Model", "[classic]") {
 
     SECTION("Repeat previous test, but also test whether time is divisible by "
             "12, and as it isn't, this should be false") {
-      REQUIRE_FALSE(!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
-                    (t % 12 == 0));
+      REQUIRE_FALSE((!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
+                    (t % 12 == 0)));
     }
   }
 }

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -23,5 +23,20 @@ TEST_CASE("Model", "[classic]") {
       REQUIRE(model.shouldReduceImportationViaPrevalance(1, 270, 270));
       REQUIRE(model.shouldReduceImportationViaPrevalance(1, 500, 270));
     }
+
+    t = 1;
+
+    SECTION("Reduce importation rate via xml, this means that the test should "
+            "be true when we run !function we are testing") {
+      REQUIRE(!model.shouldReduceImportationViaPrevalance(1, 0, 270));
+      REQUIRE_FALSE(!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
+                    t % 12 == 0);
+    }
+
+    SECTION("Repeat previous test, but also test whether time is divisible by "
+            "12, and as it isn't, this should be false") {
+      REQUIRE_FALSE(!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
+                    t % 12 == 0);
+    }
   }
 }

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -29,14 +29,12 @@ TEST_CASE("Model", "[classic]") {
     SECTION("Reduce importation rate via xml, this means that the test should "
             "be true when we run !function we are testing") {
       REQUIRE(!model.shouldReduceImportationViaPrevalance(1, 0, 270));
-      REQUIRE_FALSE(!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
-                    t % 12 == 0);
     }
 
     SECTION("Repeat previous test, but also test whether time is divisible by "
             "12, and as it isn't, this should be false") {
       REQUIRE_FALSE(!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
-                    t % 12 == 0);
+                    (t % 12 == 0));
     }
   }
 }

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -24,7 +24,7 @@ TEST_CASE("Model", "[classic]") {
       REQUIRE(model.shouldReduceImportationViaPrevalance(1, 500, 270));
     }
 
-    t = 1;
+    int t = 1;
 
     SECTION("Reduce importation rate via xml, this means that the test should "
             "be true when we run !function we are testing") {

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -34,7 +34,7 @@ TEST_CASE("Model", "[classic]") {
     SECTION("Repeat previous test, but also test whether time is divisible by "
             "12, and as it isn't, this should be false") {
       REQUIRE_FALSE((!model.shouldReduceImportationViaPrevalance(1, t, 270) &&
-                    (t % 12 == 0)));
+                     (t % 12 == 0)));
     }
   }
 }


### PR DESCRIPTION
importation rate reduction was performed for every month. This isn't what we wanted to be happening, only one reduction a year was preferred. This update does this by only making the importation rate change if the month is divisible by 12.