### PR TITLE
Include ntdmc output date

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -258,13 +258,15 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
   int HydroceleTotalWorms = popln.getHydroceleTotalWorms();
   double LymphodemaShape = popln.getLymphodemaShape();
   double HydroceleShape = popln.getHydroceleShape();
-
+  // if y != 0, then this is a simulation of a scenario which has already
+  // started and hence, we don't want to reinitialise the outputs
   if ((outputEndgame == 1) && (y == 0)) {
     sc.InitIHMEData(rep, folderName);
     sc.InitPreTASData(rep, folderName);
     sc.InitTASData(rep, folderName);
   }
-
+  // if y != 0, then this is a simulation of a scenario which has already
+  // started and hence, we don't want to reinitialise the outputs
   if ((outputNTDMC == 1) && (y == 0)) {
     sc.InitNTDMCData(rep, folderName);
   }

--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -27,7 +27,7 @@ extern Statistics stats;
 void Model::runScenarios(ScenariosList &scenarios, Population &popln,
                          Vector &vectors, Worm &worms, int replicates,
                          double timestep, int index, int outputEndgame,
-                         int outputEndgameDate, int outputNTDMC,
+                         int outputEndgameDate, bool outputNTDMC,
                          int outputNTDMCDate, int reduceImpViaXml,
                          std::string randParamsfile, std::string RandomSeedFile,
                          std::string RandomCovPropFile, std::string opDir) {
@@ -218,7 +218,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
                           int rep, std::vector<double> &k_vals,
                           std::vector<double> &v_to_h_vals, int updateParams,
                           int outputEndgame, int outputEndgameDate,
-                          int outputNTDMC, int outputNTDMCDate,
+                          bool outputNTDMC, int outputNTDMCDate,
                           int reduceImpViaXml, std::string opDir,
                           double cov_prop) {
 
@@ -267,7 +267,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
   }
   // if y != 0, then this is a simulation of a scenario which has already
   // started and hence, we don't want to reinitialise the outputs
-  if ((outputNTDMC == 1) && (y == 0)) {
+  if ((outputNTDMC == true) && (y == 0)) {
     sc.InitNTDMCData(rep, folderName);
   }
 
@@ -333,7 +333,7 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
                           folderName);
     }
 
-    if ((t % 12 == 0) && (outputNTDMC == 1) && (t >= outputNTDMCDate)) {
+    if ((t % 12 == 0) && (outputNTDMC == true) && (t >= outputNTDMCDate)) {
       sc.writeRoadmapTarget(popln, t, rep, popln.DoMDA, popln.TAS_Pass,
                             neededTASPass, folderName);
     }

--- a/src/Model.hpp
+++ b/src/Model.hpp
@@ -28,9 +28,10 @@ public:
   void runScenarios(ScenariosList &scenarios, Population &popln,
                     Vector &vectors, Worm &worms, int replicates,
                     double timestep, int index, int outputEndgame,
-                    int outputEndgameDate, int reduceImpViaXml,
-                    std::string randParamsfile, std::string RandomSeedFile,
-                    std::string RandomCovPropFile, std::string opDir);
+                    int outputEndgameDate, int outputNTDMC, int outputNTDMCDate,
+                    int reduceImpViaXml, std::string randParamsfile,
+                    std::string RandomSeedFile, std::string RandomCovPropFile,
+                    std::string opDir);
   bool
   shouldReduceImportationViaPrevalance(int t, int reduceImpViaXml,
                                        int switchImportationReducingMethodTime);
@@ -47,8 +48,9 @@ protected:
                      Scenario &sc, Output &currentOutput, int rep,
                      std::vector<double> &k_vals,
                      std::vector<double> &v_to_h_vals, int updateParams,
-                     int outputEndgame, int outputEndgameDate,
-                     int reduceImpViaXml, std::string opDir, double cov_prop);
+                     int outputEndgame, int outputEndgameDate, int outputNTDMC,
+                     int outputNTDMCDate, int reduceImpViaXml,
+                     std::string opDir, double cov_prop);
   void getRandomParameters(int index, std::vector<double> &k_vals,
                            std::vector<double> &v_to_h_vals,
                            std::vector<double> &aImp_vals,

--- a/src/Model.hpp
+++ b/src/Model.hpp
@@ -28,10 +28,10 @@ public:
   void runScenarios(ScenariosList &scenarios, Population &popln,
                     Vector &vectors, Worm &worms, int replicates,
                     double timestep, int index, int outputEndgame,
-                    int outputEndgameDate, int outputNTDMC, int outputNTDMCDate,
-                    int reduceImpViaXml, std::string randParamsfile,
-                    std::string RandomSeedFile, std::string RandomCovPropFile,
-                    std::string opDir);
+                    int outputEndgameDate, bool outputNTDMC,
+                    int outputNTDMCDate, int reduceImpViaXml,
+                    std::string randParamsfile, std::string RandomSeedFile,
+                    std::string RandomCovPropFile, std::string opDir);
   bool
   shouldReduceImportationViaPrevalance(int t, int reduceImpViaXml,
                                        int switchImportationReducingMethodTime);
@@ -48,7 +48,7 @@ protected:
                      Scenario &sc, Output &currentOutput, int rep,
                      std::vector<double> &k_vals,
                      std::vector<double> &v_to_h_vals, int updateParams,
-                     int outputEndgame, int outputEndgameDate, int outputNTDMC,
+                     int outputEndgame, int outputEndgameDate, bool outputNTDMC,
                      int outputNTDMCDate, int reduceImpViaXml,
                      std::string opDir, double cov_prop);
   void getRandomParameters(int index, std::vector<double> &k_vals,

--- a/src/Scenario.cpp
+++ b/src/Scenario.cpp
@@ -853,6 +853,7 @@ void Scenario::InitNTDMCData(int rep, std::string folder) {
   if (stat(fname2.c_str(), &buffer) != 0) {
     fs::create_directories(fname2);
   }
+
   std::ofstream outfile;
   outfile.open(fname);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,10 +73,10 @@ int main(int argc, char **argv) {
   // xml file rather than impact of MDA on the prevalence
   int outputEndgame = 1;
   int outputEndgameDate = 2000;
-  int outputNTDMC = 1;
+  bool outputNTDMC = true;
   int outputNTDMCDate = 2000;
   int reduceImpViaXml = 0;
-
+  int NTDMC = 1;
   int index = 0;
   if (!strcmp(argv[1], "DEBUG")) {
     _DEBUG = true;
@@ -115,7 +115,7 @@ int main(int argc, char **argv) {
     else if (!strcmp(argv[i], "-D"))
       outputEndgameDate = atoi(argv[i + 1]);
     else if (!strcmp(argv[i], "-m"))
-      outputNTDMC = atoi(argv[i + 1]);
+      NTDMC = atoi(argv[i + 1]);
     else if (!strcmp(argv[i], "-N"))
       outputNTDMCDate = atoi(argv[i + 1]);
     else if (!strcmp(argv[i], "-x"))
@@ -126,7 +126,10 @@ int main(int argc, char **argv) {
       return 1;
     }
   }
-
+  if (NTDMC == 0) {
+    outputNTDMC = false;
+  }
+  std::cout << "outputNTDMC = " << outputNTDMC << std::endl;
   for (int i = 0; i < argc; i++)
     std::cout << argv[i] << " ";
   std::cout << std::endl << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,8 @@ int main(int argc, char **argv) {
   // xml file rather than impact of MDA on the prevalence
   int outputEndgame = 1;
   int outputEndgameDate = 2000;
+  int outputNTDMC = 1;
+  int outputNTDMCDate = 2000;
   int reduceImpViaXml = 0;
 
   int index = 0;
@@ -112,6 +114,10 @@ int main(int argc, char **argv) {
       outputEndgame = atoi(argv[i + 1]);
     else if (!strcmp(argv[i], "-D"))
       outputEndgameDate = atoi(argv[i + 1]);
+    else if (!strcmp(argv[i], "-m"))
+      outputNTDMC = atoi(argv[i + 1]);
+    else if (!strcmp(argv[i], "-N"))
+      outputNTDMCDate = atoi(argv[i + 1]);
     else if (!strcmp(argv[i], "-x"))
       reduceImpViaXml = atoi(argv[i + 1]);
     else {
@@ -193,9 +199,9 @@ int main(int argc, char **argv) {
   // Run
   Model model;
   model.runScenarios(Scenarios, hostPopulation, vectors, worms, replicates, dt,
-                     index, outputEndgame, outputEndgameDate, reduceImpViaXml,
-                     randParamsfile, RandomSeedFile, CoverageReductionFile,
-                     opDir);
+                     index, outputEndgame, outputEndgameDate, outputNTDMC,
+                     outputNTDMCDate, reduceImpViaXml, randParamsfile,
+                     RandomSeedFile, CoverageReductionFile, opDir);
 
   gettimeofday(&tv2, NULL);
   double timesofar = (double)(tv2.tv_usec - tv1.tv_usec) / 1000000.0 +

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,8 @@ int main(int argc, char **argv) {
       return 1;
     }
   }
+  // input "-m 0" when running from command line if we don't want to
+  // output NTDMC data.
   if (NTDMC == 0) {
     outputNTDMC = false;
   }


### PR DESCRIPTION
the output of IHME and NTDMC data has been linked in the code up to this point, not allowing us to output all of the NTDMC data without outputting all of the IHME data. Include an indicator and date of NTDMC outputs, so that we can separate these two data sets and allow us to output them from different dates, or output one without the other.