### PR TITLE
Remove deprecated Mac version from CI

### DIFF
--- a/.github/workflows/check-compilation-across-os.yml
+++ b/.github/workflows/check-compilation-across-os.yml
@@ -18,7 +18,7 @@ jobs:
   Macos-latest:
     strategy:
       matrix:
-        os: [macos-12, macos-13, macos-latest]
+        os: [macos-13, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code


### PR DESCRIPTION
Github no longer supports this image
https://github.com/actions/runner-images/issues/10721