### PR TITLE
Add install GSL step to linux jobs

### DIFF
--- a/.github/workflows/check-compilation-across-os.yml
+++ b/.github/workflows/check-compilation-across-os.yml
@@ -4,7 +4,7 @@ jobs:
   Ubuntu-latest:
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-20.04]
+        os: [ubuntu-latest, ubuntu-20.04, ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Check out repository code

--- a/.github/workflows/check-compilation-across-os.yml
+++ b/.github/workflows/check-compilation-across-os.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Build
         run: |
+          sudo apt install gsl-bin libgsl-dev
           mkdir build && cd build/
           cmake .. -DBUILD_TESTS=OFF
           cmake --build .

--- a/.github/workflows/format-and-test.yml
+++ b/.github/workflows/format-and-test.yml
@@ -22,7 +22,8 @@ jobs:
           cmake -B build -S . -DBUILD_TESTING=OFF
           sudo cmake --build build/ --target install
           cd ..
-
+          
+          sudo apt install gsl-bin libgsl-dev
           mkdir build && cd build/
           cmake ..
           cmake --build .


### PR DESCRIPTION
CI is currently failing on [ubuntu-latest](https://github.com/NTD-Modelling-Consortium/LF/actions/runs/12689021466/job/35580001900) 

The README specifies that [GSL](https://www.gnu.org/software/gsl/)  needs to be installed manually, (and on the Mac job it is). I guess it was installed anyway on older versions of Ubuntu, but 24.04 doesn't seem to have it, and GH have just upgraded ubuntu-latest to 24.04. 