### PR TITLE
Add interventions to ntdmc data

### DIFF
--- a/src/Model.cpp
+++ b/src/Model.cpp
@@ -295,6 +295,10 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
   int roundNumber =
       1; // initialize an integer to track which round of MDA in a year is being
          // done and will be recorded in the IHME output
+  int totalTreatmentsThisYear =
+      0; // track how many treatments are done each year, to be output in NTDMC
+         // data set intialize a variable to track this, which will be reset to
+         // 0 each year if we are outputting this data set.
   for (int q = 0; q < popln.sensSpecChangeCount; q++) {
     if (popln.sensSpecChangeName[q] == sc.getName()) {
       changeSensSpec = 1;
@@ -339,7 +343,8 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
     if ((t % 12 == 0) && (outputNTDMC == true) &&
         (t >= outputNTDMCDateFromYear)) {
       sc.writeRoadmapTarget(popln, t, rep, popln.DoMDA, popln.TAS_Pass,
-                            neededTASPass, folderName);
+                            totalTreatmentsThisYear, neededTASPass, folderName);
+      totalTreatmentsThisYear = 0;
     }
 
     // If we haven't done a survey this year we still want to output this fact
@@ -511,9 +516,9 @@ void Model::evolveAndSave(int y, Population &popln, Vector &vectors,
       // apply the MDA. If popln.DoMDA = false, then we call this function, but
       // don't do the MDA, we just write to a file showing that no people were
       // treated.
-      popln.ApplyTreatmentUpdated(applyMDA, worms, sc, t, roundNumber,
-                                  outputEndgameDate, rep, popln.DoMDA,
-                                  outputEndgame, folderName);
+      totalTreatmentsThisYear += popln.ApplyTreatmentUpdated(
+          applyMDA, worms, sc, t, roundNumber, outputEndgameDate, rep,
+          popln.DoMDA, outputEndgame, folderName);
       time_to_reduce_importation_rate = t + 6;
 
       popln.totMDAs += 1;

--- a/src/Population.cpp
+++ b/src/Population.cpp
@@ -1249,7 +1249,7 @@ int Population::returnMinAgeMDA(MDAEvent *mda) {
 
 int Population::returnMaxAge() { return maxAge; }
 
-void Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
+int Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
                                        int t, int roundNumber,
                                        int outputEndgameDate, int rep,
                                        bool DoMDA, int outputEndgame,
@@ -1266,6 +1266,7 @@ void Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
   std::vector<int> numHostsByAge(maxAge, 0);
 
   std::string MDAtype = mda->getType();
+  int totalTreatments = 0;
 
   for (int i = 0; i < size; i++) {
     float flooredAge = std::floor(host_pop[i].age / 12);
@@ -1277,6 +1278,7 @@ void Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
           if (host_pop[i].neverTreat == 0) {
             host_pop[i].getsTreated(worms, MDAtype);
             numTreatedByAge[flooredAgeInt] += 1;
+            totalTreatments += 1;
           }
         }
       }
@@ -1285,6 +1287,7 @@ void Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
   if ((outputEndgame == 1) && (t >= outputEndgameDate))
     sc.writeMDADataAllTreated(t, roundNumber, numTreatedByAge, numHostsByAge,
                               maxAge, rep, MDAtype, folderName);
+  return totalTreatments;
 }
 
 double Population::getBedNetCoverage() const {

--- a/src/Population.cpp
+++ b/src/Population.cpp
@@ -1250,16 +1250,16 @@ int Population::returnMinAgeMDA(MDAEvent *mda) {
 int Population::returnMaxAge() { return maxAge; }
 
 int Population::ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc,
-                                       int t, int roundNumber,
-                                       int outputEndgameDate, int rep,
-                                       bool DoMDA, int outputEndgame,
-                                       std::string folderName) {
+                                      int t, int roundNumber,
+                                      int outputEndgameDate, int rep,
+                                      bool DoMDA, int outputEndgame,
+                                      std::string folderName) {
   int minAge = (mda->getMinAge() >= 0) ? mda->getMinAge() : minAgeMDA;
   int minAgeMDAinMonths = minAge * 12;
 
   if (maxAge <= 0 || size <= 0) {
     std::cerr << "Invalid maxAge or size" << std::endl;
-    return;
+    return 0;
   }
 
   std::vector<int> numTreatedByAge(maxAge, 0);

--- a/src/Population.hpp
+++ b/src/Population.hpp
@@ -97,7 +97,7 @@ public:
   void evolve(double dt, const Vector &vectors, const Worm &worms);
   void ApplyTreatment(MDAEvent *mda, Worm &worms, Scenario &sc, int t, int rep,
                       std::string folderName);
-  void ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc, int t,
+  int ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc, int t,
                              int roundNumber, int outputEndgameDate, int rep,
                              bool DoMDA, int outputEndgame,
                              std::string folderName);

--- a/src/Population.hpp
+++ b/src/Population.hpp
@@ -98,9 +98,9 @@ public:
   void ApplyTreatment(MDAEvent *mda, Worm &worms, Scenario &sc, int t, int rep,
                       std::string folderName);
   int ApplyTreatmentUpdated(MDAEvent *mda, Worm &worms, Scenario &sc, int t,
-                             int roundNumber, int outputEndgameDate, int rep,
-                             bool DoMDA, int outputEndgame,
-                             std::string folderName);
+                            int roundNumber, int outputEndgameDate, int rep,
+                            bool DoMDA, int outputEndgame,
+                            std::string folderName);
   void saveCurrentState(int month, std::string sname);
   void resetToMonth(int month);
   void clearSavedMonths();

--- a/src/Scenario.cpp
+++ b/src/Scenario.cpp
@@ -643,8 +643,8 @@ void Scenario::writePrevByAge(Population &popln, int t, int rep,
 }
 
 void Scenario::writeRoadmapTarget(Population &popln, int t, int rep, int DoMDA,
-                                  int TAS_Pass, int neededTASPass,
-                                  std::string folder) {
+                                  int TAS_Pass, int totalTreatmentsThisYear,
+                                  int neededTASPass, std::string folder) {
   // we want to write whether the population has reached the 2030 roadmap target
   // for each year for LF this is to have microfilaria prevalence below 1% in
   // people 5 years and older we also write the mf prevalence for people 5 years
@@ -686,6 +686,9 @@ void Scenario::writeRoadmapTarget(Population &popln, int t, int rep, int DoMDA,
     outfile << name << "," << year << "," << 5 << "," << maxAge << ","
             << "metRoadmapTarget"
             << "," << roadmapTargetMet << "\n";
+    outfile << name << "," << year << "," << "None" << "," << "None" << ","
+            << "MDA doses"
+            << "," << totalTreatmentsThisYear << "\n";
     outfile << name << "," << year << ","
             << "None"
             << ","
@@ -705,6 +708,7 @@ void Scenario::writeRoadmapTarget(Population &popln, int t, int rep, int DoMDA,
     outfile << ICprevSample << "\n";
     outfile << ICprevTrue << "\n";
     outfile << roadmapTargetMet << "\n";
+    outfile << totalTreatmentsThisYear << "\n";
     outfile << 1 - DoMDA << "\n";
     outfile << achieveEPHP << "\n";
   }

--- a/src/Scenario.hpp
+++ b/src/Scenario.hpp
@@ -173,7 +173,8 @@ public:
   void InitTASData(int rep, std::string folder);
   void writePrevByAge(Population &popln, int t, int rep, std::string folder);
   void writeRoadmapTarget(Population &popln, int t, int rep, int DoMDA,
-                          int TAS_Pass, int neededTASPass, std::string folder);
+                          int TAS_Pass, int totalTreatmentsThisYear,
+                          int neededTASPass, std::string folder);
   void writeNumberByAge(Population &popln, int t, int rep, std::string folder,
                         std::string surveyType);
   void writeSequelaeByAge(Population &popln, int t, int LymphodemaTotalWorms,


### PR DESCRIPTION
output the number of interventions given out each year for the NTDMC data. This is currently done on the first day of the year, so the number of interventions specified for each year is actually the number of treatments done in the previous year.